### PR TITLE
added support for multiple slack files & user tags

### DIFF
--- a/src/make-gif.js
+++ b/src/make-gif.js
@@ -52,5 +52,5 @@ module.exports = async function(settings){
     title: `title for ${path.basename(gifResult.gifPath)}`,
     channels: process.env.SLACK_SHOW_YOUR_IMAGES_CHANNEL
   })
-  return ({downloadPath: downloadPath, gifResult: gifResult})
+  return ({downloadPath: downloadPath, gifResult: gifResult, slackResult: slackResult})
 };


### PR DESCRIPTION
need to add "TaggedSlackUsers" column in airtable table to work!

the bot should now be able to submit multiple image/gif/video files to airtable & reply with markdown

also records @ tags in slack messages to simplify LLUF submission from LL computers with their own tags